### PR TITLE
fix: Jest config for @faker-js/faker v10 ESM support

### DIFF
--- a/packages/apps/backend/tests/jest.config.ts
+++ b/packages/apps/backend/tests/jest.config.ts
@@ -16,8 +16,17 @@ const config: Config = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.spec.ts'],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        module: 'commonjs',
+        allowSyntheticDefaultImports: true,
+        esModuleInterop: true
+      }
+    }],
   },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@faker-js/faker)/)'
+  ],
   testPathIgnorePatterns: ignorePatterns,
   coverageDirectory: '<rootDir>/coverage',
   coveragePathIgnorePatterns: [...ignorePatterns, 'main.ts', '.*\\.module\\.ts$'],


### PR DESCRIPTION
## 概要
@faker-js/faker v10へのアップデートに伴うESモジュールサポートの問題を修正

## 問題
@faker-js/faker v10は完全にESモジュールに移行したため、CommonJSベースのJest設定では以下のエラーが発生：
```
SyntaxError: Cannot use import statement outside a module
```

## 解決策
Jest設定を更新してESモジュールをサポート：
- ts-jestのtransform設定にオプションを追加
- `transformIgnorePatterns`に@faker-js/fakerを追加して、node_modules内でもトランスパイル対象に含める
- CommonJSモジュールへの変換を有効化

## テスト
この変更により、@faker-js/faker v10でもテストが正常に動作するようになります。