### PR TITLE
feat(backend): add Phase 3 observability - tracing, metrics, RFC 7807

### DIFF
--- a/packages/apps/admin/generated/types/api.d.ts
+++ b/packages/apps/admin/generated/types/api.d.ts
@@ -174,10 +174,18 @@ export interface components {
             users: components["schemas"]["UserResponseDto"][];
         };
         ErrorResponseDto: {
+            /** @example https://developer.music-practice-tracker.com/errors/AP0400 */
+            type: string;
+            /** @example Bad request. */
+            title: string;
             /** @example 400 */
-            statusCode: number;
-            /** @example RE0002 */
+            status: number;
+            /** @example AP0400 */
             errorCode: string;
+            /** @example req-uuid-xxx */
+            correlationId?: string;
+            /** @example /api/v1/users */
+            instance?: string;
         };
         CreateUserInputDto: {
             /**

--- a/packages/apps/backend/src/apis/admin/admin.module.ts
+++ b/packages/apps/backend/src/apis/admin/admin.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 
 import { CommonModule } from '../app/utils/common.module';
 import { GlobalExceptionFilter } from '../utils/filters/global-exception.filter';
 import { HealthModule } from '../utils/health/health.module';
+import { TracingInterceptor } from '../utils/interceptors/tracing.interceptor';
 import { ObservabilityModule } from '../utils/modules/observability.module';
 
 import { AdminAdminUsersModule } from './admin-users/admin-users.module';
@@ -25,6 +26,10 @@ import { AdminUsersModule } from './users/users.module';
     {
       provide: APP_FILTER,
       useClass: GlobalExceptionFilter,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: TracingInterceptor,
     },
   ],
 })

--- a/packages/apps/backend/src/apis/app/app.module.ts
+++ b/packages/apps/backend/src/apis/app/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 
 import { GlobalExceptionFilter } from '../utils/filters/global-exception.filter';
 import { HealthModule } from '../utils/health/health.module';
+import { TracingInterceptor } from '../utils/interceptors/tracing.interceptor';
 import { ObservabilityModule } from '../utils/modules/observability.module';
 
 import { AppApiUsersModule } from './users/users.module';
@@ -28,6 +29,10 @@ import { UserAuthGuard } from './utils/guards/user-auth.guard';
     {
       provide: APP_GUARD,
       useClass: UserAuthGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: TracingInterceptor,
     },
   ],
 })

--- a/packages/apps/backend/src/apis/utils/api.error.ts
+++ b/packages/apps/backend/src/apis/utils/api.error.ts
@@ -131,10 +131,26 @@ export const HTTP_STATUS_ERROR_CODE_RECORD_BY_REPOSITORY_ERROR_CODE: Record<Repo
   RE9999: HttpStatus.INTERNAL_SERVER_ERROR, // Unknown repository error
 };
 
-export class ErrorResponseDto {
-  @ApiProperty({ example: 400 })
-  public statusCode: HttpStatus;
+const ERROR_TYPE_BASE_URL = 'https://developer.music-practice-tracker.com/errors';
 
-  @ApiProperty({ example: 'RE0002' })
+export const buildErrorTypeUrl = (errorCode: ErrorCode): string => `${ERROR_TYPE_BASE_URL}/${errorCode}`;
+
+export class ErrorResponseDto {
+  @ApiProperty({ example: 'https://developer.music-practice-tracker.com/errors/AP0400' })
+  public type: string;
+
+  @ApiProperty({ example: 'Bad request.' })
+  public title: string;
+
+  @ApiProperty({ example: 400 })
+  public status: number;
+
+  @ApiProperty({ example: 'AP0400' })
   public errorCode: ErrorCode;
+
+  @ApiProperty({ example: 'req-uuid-xxx', required: false })
+  public correlationId?: string;
+
+  @ApiProperty({ example: '/api/v1/users', required: false })
+  public instance?: string;
 }

--- a/packages/apps/backend/src/apis/utils/filters/global-exception.filter.ts
+++ b/packages/apps/backend/src/apis/utils/filters/global-exception.filter.ts
@@ -6,6 +6,7 @@ import { PinoLogger } from 'nestjs-pino';
 
 import {
   ApiError,
+  buildErrorTypeUrl,
   ErrorResponseDto,
   HTTP_STATUS_ERROR_CODE_RECORD_BY_REPOSITORY_ERROR_CODE,
   isApiError,
@@ -19,11 +20,13 @@ import {
   RepositoryError,
 } from '@/repository/utils/repository.error';
 import { CommonError } from '@/utils/errors/common.error';
-import { apiErrorPrefix, isErrorCode } from '@/utils/errors/error-code';
+import { apiErrorPrefix, ERROR_CODE_RECORDS, type ErrorCode, isErrorCode } from '@/utils/errors/error-code';
 import { ErrorSeverity } from '@/utils/errors/error-severity';
 import { isUnknownError, UnknownError } from '@/utils/errors/unknown.error';
 
 const httpErrorCodePrefix = `${apiErrorPrefix}0`;
+
+type BuildResult = { errorResponse: ErrorResponseDto; resolvedException: unknown };
 
 @Injectable()
 @Catch()
@@ -41,6 +44,9 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
 
     const { errorResponse, resolvedException } = this.buildErrorResponse(exception);
+    errorResponse.correlationId = this.cls.getId();
+    errorResponse.instance = request.url;
+
     try {
       this.logError(resolvedException, errorResponse, request);
     } catch (loggingError: unknown) {
@@ -53,7 +59,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       // eslint-disable-next-line no-console -- last-resort fallback when Datadog reporting fails
       console.warn('GlobalExceptionFilter: reportToDatadog failed', datadogError);
     }
-    response.status(errorResponse.statusCode).json(errorResponse);
+    response.status(errorResponse.status).header('Content-Type', 'application/problem+json').json(errorResponse);
   }
 
   private logError(exception: unknown, errorResponse: ErrorResponseDto, request: Request): void {
@@ -62,7 +68,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const baseLogEntry = {
       correlationId,
       userId,
-      statusCode: errorResponse.statusCode,
+      statusCode: errorResponse.status,
       errorCode: errorResponse.errorCode,
       method: request.method,
       url: request.url,
@@ -111,7 +117,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       span.setTag('error', true);
       span.setTag('error.type', exception instanceof Error ? exception.name : 'UnknownError');
       span.setTag('error.code', errorResponse.errorCode);
-      span.setTag('http.status_code', errorResponse.statusCode);
+      span.setTag('http.status_code', errorResponse.status);
 
       if (exception instanceof CommonError) {
         span.setTag('error.severity', exception.severity);
@@ -141,10 +147,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     tracer.dogstatsd.increment('app.error.count', undefined, metricTags);
   }
 
-  private buildErrorResponse(exception: unknown): {
-    errorResponse: ErrorResponseDto;
-    resolvedException: unknown;
-  } {
+  private buildErrorResponse(exception: unknown): BuildResult {
     if (exception instanceof HttpException) {
       return { errorResponse: this.handleHttpException(exception), resolvedException: exception };
     }
@@ -170,82 +173,70 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       return { errorResponse: this.handleUnknownError(exception), resolvedException: exception };
     }
 
-    const errorCode = 'UN9999';
+    const errorCode = 'UN9999' as const;
 
     return {
-      errorResponse: {
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-        errorCode,
-      },
+      errorResponse: this.toRfc7807(HttpStatus.INTERNAL_SERVER_ERROR, errorCode),
       resolvedException: exception,
     };
   }
 
-  private handleHttpException(exception: HttpException): ErrorResponseDto {
-    const statusCode = exception.getStatus();
-    const _errorCode = `${httpErrorCodePrefix}${statusCode}`;
-    const errorCode = isErrorCode(_errorCode) ? _errorCode : 'AP9999';
-
+  private toRfc7807(status: number, errorCode: ErrorCode): ErrorResponseDto {
     return {
-      statusCode,
+      type: buildErrorTypeUrl(errorCode),
+      title: ERROR_CODE_RECORDS[errorCode],
+      status,
       errorCode,
     };
   }
 
+  private handleHttpException(exception: HttpException): ErrorResponseDto {
+    const status = exception.getStatus();
+    const _errorCode = `${httpErrorCodePrefix}${status}`;
+    const errorCode = isErrorCode(_errorCode) ? _errorCode : 'AP9999';
+
+    return this.toRfc7807(status, errorCode);
+  }
+
   private handleApiError(exception: ApiError): ErrorResponseDto {
     const statusMatch = /^AP0(?<status>\d{3})$/u.exec(exception.errorCode);
-    const statusCode =
+    const status =
       statusMatch?.groups?.status !== undefined && statusMatch.groups.status !== ''
         ? parseInt(statusMatch.groups.status, 10)
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    return {
-      statusCode,
-      errorCode: exception.errorCode,
-    };
+    return this.toRfc7807(status, exception.errorCode);
   }
 
   private handleDomainError(exception: DomainError): ErrorResponseDto {
-    return {
-      statusCode: HttpStatus.BAD_REQUEST,
-      errorCode: exception.errorCode,
-    };
+    return this.toRfc7807(HttpStatus.BAD_REQUEST, exception.errorCode);
   }
 
   private handleFirebaseError(exception: FirebaseError): ErrorResponseDto {
     const { errorCode } = exception;
-    let statusCode = HttpStatus.UNAUTHORIZED;
+    let status = HttpStatus.UNAUTHORIZED;
 
     if (errorCode === 'FB0003' || errorCode === 'FB0004') {
-      statusCode = HttpStatus.CONFLICT;
+      status = HttpStatus.CONFLICT;
     } else if (errorCode === 'FB0005') {
-      statusCode = HttpStatus.NOT_FOUND;
+      status = HttpStatus.NOT_FOUND;
     } else if (errorCode === 'FB0006' || errorCode === 'FB0007') {
-      statusCode = HttpStatus.UNAUTHORIZED;
+      status = HttpStatus.UNAUTHORIZED;
     } else if (errorCode === 'FB0008') {
-      statusCode = HttpStatus.FORBIDDEN;
+      status = HttpStatus.FORBIDDEN;
     } else if (errorCode === 'FB9999') {
-      statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+      status = HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
-    return {
-      statusCode,
-      errorCode: exception.errorCode,
-    };
+    return this.toRfc7807(status, exception.errorCode);
   }
 
   private handleRepositoryError(exception: RepositoryError): ErrorResponseDto {
-    const statusCode = HTTP_STATUS_ERROR_CODE_RECORD_BY_REPOSITORY_ERROR_CODE[exception.errorCode];
-    return {
-      statusCode,
-      errorCode: exception.errorCode,
-    };
+    const status = HTTP_STATUS_ERROR_CODE_RECORD_BY_REPOSITORY_ERROR_CODE[exception.errorCode];
+    return this.toRfc7807(status, exception.errorCode);
   }
 
   private handleUnknownError(exception: UnknownError): ErrorResponseDto {
-    return {
-      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-      errorCode: exception.errorCode,
-    };
+    return this.toRfc7807(HttpStatus.INTERNAL_SERVER_ERROR, exception.errorCode);
   }
 }

--- a/packages/apps/backend/src/apis/utils/interceptors/tracing.interceptor.ts
+++ b/packages/apps/backend/src/apis/utils/interceptors/tracing.interceptor.ts
@@ -1,0 +1,15 @@
+import { type CallHandler, type ExecutionContext, Injectable, type NestInterceptor } from '@nestjs/common';
+import tracer from 'dd-trace';
+import { type Observable, from } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class TracingInterceptor implements NestInterceptor {
+  public intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const controller = context.getClass().name;
+    const handler = context.getHandler().name;
+    const resource = `${controller}.${handler}`;
+
+    return from(tracer.trace('nestjs.handler', { resource }, () => firstValueFrom(next.handle())));
+  }
+}

--- a/packages/apps/backend/src/domain/aggregates/user/user.command.service.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/user.command.service.ts
@@ -13,13 +13,16 @@ import {
 } from './utils/dto';
 
 import { RepositoryService } from '@/repository/repository.service';
+import { Metrics } from '@/utils/metrics/dogstatsd.metrics';
 
 @Injectable()
 export class UserCommandService {
   public constructor(private readonly repository: RepositoryService) {}
 
   public async createUser(dto: CreateUserInputDto): Promise<UserResponseDto> {
-    return toUserResponseDto(await this.repository.user.create({ data: dto }));
+    const user = toUserResponseDto(await this.repository.user.create({ data: dto }));
+    Metrics.incrementUserCreated();
+    return user;
   }
 
   public async createManyAndReturnUsers({ users }: CreateManyUsersInputDto): Promise<UsersResponseDto> {

--- a/packages/apps/backend/src/domain/usecases/user/delete-user.service.ts
+++ b/packages/apps/backend/src/domain/usecases/user/delete-user.service.ts
@@ -3,6 +3,8 @@ import { Injectable } from '@nestjs/common';
 import { UserCommandService } from '@/domain/aggregates/user/user.command.service';
 import { UserQueryService } from '@/domain/aggregates/user/user.query.service';
 import { FirebaseAuthService } from '@/firebase-auth/firebase-auth.service';
+import { Trace } from '@/utils/decorators/trace.decorator';
+import { Metrics } from '@/utils/metrics/dogstatsd.metrics';
 
 @Injectable()
 export class DeleteUserService {
@@ -12,10 +14,12 @@ export class DeleteUserService {
     private readonly usersCommand: UserCommandService,
   ) {}
 
+  @Trace()
   public async execute(publicId: string): Promise<void> {
     // Delete from Firebase first (treat "user-not-found" as success) → then physically delete from DB
     const user = await this.usersQuery.findUniqueOrThrowUserById({ publicId });
     await this.firebaseAuth.deleteUser(user.firebaseUid);
     await this.usersCommand.deleteUserById({ publicId });
+    Metrics.incrementUserDeleted();
   }
 }

--- a/packages/apps/backend/src/tracer.ts
+++ b/packages/apps/backend/src/tracer.ts
@@ -1,5 +1,7 @@
 import tracer from 'dd-trace';
 
+// service, env, version are configured via DD_SERVICE, DD_ENV, DD_VERSION environment variables.
+// Each app (App API / Admin API) sets DD_SERVICE to its own identifier.
 try {
   tracer.init({
     logInjection: true,

--- a/packages/apps/backend/src/utils/decorators/trace.decorator.ts
+++ b/packages/apps/backend/src/utils/decorators/trace.decorator.ts
@@ -1,0 +1,19 @@
+import tracer from 'dd-trace';
+
+export function Trace(operationName?: string) {
+  return function traceDecorator(
+    _target: object,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ): PropertyDescriptor {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- PropertyDescriptor.value is untyped
+    const original = descriptor.value;
+    // eslint-disable-next-line func-name-matching -- named for stack trace readability; assigned to descriptor.value
+    descriptor.value = function traceWrapper(this: object, ...args: unknown[]): unknown {
+      const name = operationName ?? `${this.constructor.name}.${String(propertyKey)}`;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- decorator wraps original method
+      return tracer.trace('domain.operation', { resource: name }, () => original.apply(this, args));
+    };
+    return descriptor;
+  };
+}

--- a/packages/apps/backend/src/utils/metrics/dogstatsd.metrics.ts
+++ b/packages/apps/backend/src/utils/metrics/dogstatsd.metrics.ts
@@ -1,0 +1,10 @@
+import tracer from 'dd-trace';
+
+export const Metrics = {
+  incrementUserCreated: (): void => {
+    tracer.dogstatsd.increment('app.user.created');
+  },
+  incrementUserDeleted: (): void => {
+    tracer.dogstatsd.increment('app.user.deleted');
+  },
+} as const;

--- a/packages/apps/backend/tests/src/apis/utils/api.error.spec.ts
+++ b/packages/apps/backend/tests/src/apis/utils/api.error.spec.ts
@@ -177,7 +177,9 @@ describe('class ErrorResponseDto', () => {
   it('should have correct structure', () => {
     const dto = new ErrorResponseDto();
 
-    expect(dto).toHaveProperty('statusCode');
+    expect(dto).toHaveProperty('type');
+    expect(dto).toHaveProperty('title');
+    expect(dto).toHaveProperty('status');
     expect(dto).toHaveProperty('errorCode');
   });
 });

--- a/packages/apps/backend/tests/src/apis/utils/filters/global-exception.filter.spec.ts
+++ b/packages/apps/backend/tests/src/apis/utils/filters/global-exception.filter.spec.ts
@@ -33,6 +33,8 @@ const mockSpan = mockActive() as { setTag: jest.Mock };
 const mockSetTag = mockSpan.setTag;
 const mockIncrement = jest.mocked(ddTraceMock.dogstatsd.increment);
 
+const BASE_URL = 'https://developer.music-practice-tracker.com/errors';
+
 describe('unit GlobalExceptionFilter', () => {
   let filter: GlobalExceptionFilter;
   let mockResponse: Partial<Response>;
@@ -69,6 +71,7 @@ describe('unit GlobalExceptionFilter', () => {
 
     mockResponse = {
       status: jest.fn().mockReturnThis(),
+      header: jest.fn().mockReturnThis(),
       json: jest.fn(),
     };
 
@@ -100,9 +103,14 @@ describe('unit GlobalExceptionFilter', () => {
       filter.catch(exception, mockArgumentsHost as ArgumentsHost);
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(mockResponse.header).toHaveBeenCalledWith('Content-Type', 'application/problem+json');
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.BAD_REQUEST,
+        type: `${BASE_URL}/AP0400`,
+        title: 'Bad request',
+        status: HttpStatus.BAD_REQUEST,
         errorCode: 'AP0400',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -113,8 +121,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(499);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: 499,
+        type: `${BASE_URL}/AP9999`,
+        title: 'Unknown application error.',
+        status: 499,
         errorCode: 'AP9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -125,8 +137,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.UNAUTHORIZED,
+        type: `${BASE_URL}/AP0401`,
+        title: 'Unauthorized',
+        status: HttpStatus.UNAUTHORIZED,
         errorCode: 'AP0401',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -137,8 +153,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        type: `${BASE_URL}/AP9999`,
+        title: 'Unknown application error.',
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
         errorCode: 'AP9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -149,8 +169,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.BAD_REQUEST,
+        type: `${BASE_URL}/DO9999`,
+        title: 'Unknown domain error.',
+        status: HttpStatus.BAD_REQUEST,
         errorCode: 'DO9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -164,8 +188,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.BAD_REQUEST,
+        type: `${BASE_URL}/RE0001`,
+        title: 'Column value too long for database field.',
+        status: HttpStatus.BAD_REQUEST,
         errorCode: 'RE0001',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -180,8 +208,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.NOT_FOUND,
+        type: `${BASE_URL}/RE0002`,
+        title: 'Record not found in database.',
+        status: HttpStatus.NOT_FOUND,
         errorCode: 'RE0002',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -192,8 +224,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.CONFLICT,
+        type: `${BASE_URL}/FB0003`,
+        title: 'Failed to initialize Firebase Admin SDK.',
+        status: HttpStatus.CONFLICT,
         errorCode: 'FB0003',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -204,8 +240,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.CONFLICT,
+        type: `${BASE_URL}/FB0004`,
+        title: 'Firebase token expired.',
+        status: HttpStatus.CONFLICT,
         errorCode: 'FB0004',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -216,8 +256,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.NOT_FOUND,
+        type: `${BASE_URL}/FB0005`,
+        title: 'Firebase token revoked.',
+        status: HttpStatus.NOT_FOUND,
         errorCode: 'FB0005',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -228,8 +272,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.UNAUTHORIZED,
+        type: `${BASE_URL}/FB0006`,
+        title: 'Firebase invalid token.',
+        status: HttpStatus.UNAUTHORIZED,
         errorCode: 'FB0006',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -240,8 +288,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.UNAUTHORIZED,
+        type: `${BASE_URL}/FB0007`,
+        title: 'Firebase user not found.',
+        status: HttpStatus.UNAUTHORIZED,
         errorCode: 'FB0007',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -252,8 +304,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.FORBIDDEN,
+        type: `${BASE_URL}/FB0008`,
+        title: 'Failed to delete Firebase user.',
+        status: HttpStatus.FORBIDDEN,
         errorCode: 'FB0008',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -264,8 +320,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        type: `${BASE_URL}/FB9999`,
+        title: 'Unknown Firebase error.',
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
         errorCode: 'FB9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -276,8 +336,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.UNAUTHORIZED,
+        type: `${BASE_URL}/FB0001`,
+        title: 'Firebase Admin credential not configured.',
+        status: HttpStatus.UNAUTHORIZED,
         errorCode: 'FB0001',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -288,8 +352,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        type: `${BASE_URL}/UN9999`,
+        title: 'Unknown error.',
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
         errorCode: 'UN9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -300,8 +368,12 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        type: `${BASE_URL}/UN9999`,
+        title: 'Unknown error.',
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
         errorCode: 'UN9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
     });
 
@@ -312,9 +384,37 @@ describe('unit GlobalExceptionFilter', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(999);
       expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: 999,
+        type: `${BASE_URL}/AP9999`,
+        title: 'Unknown application error.',
+        status: 999,
         errorCode: 'AP9999',
+        correlationId: 'test-correlation-id',
+        instance: '/test',
       });
+    });
+
+    it('should set Content-Type to application/problem+json', () => {
+      const exception = new DomainError('DO9999', 'Test error');
+
+      filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+      expect(mockResponse.header).toHaveBeenCalledWith('Content-Type', 'application/problem+json');
+    });
+
+    it('should include correlationId and instance in every response', () => {
+      mockCls.getId.mockReturnValue('custom-corr-id');
+      (mockRequest as { url: string }).url = '/api/v1/users/me';
+
+      const exception = new ApiError('AP0400', 'Bad request');
+
+      filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          correlationId: 'custom-corr-id',
+          instance: '/api/v1/users/me',
+        }),
+      );
     });
   });
 
@@ -442,8 +542,8 @@ describe('unit GlobalExceptionFilter', () => {
     it('should fallback to console.error when logError throws', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
-      mockCls.getId.mockImplementation(() => {
-        throw new Error('CLS failure');
+      mockCls.get.mockImplementation(() => {
+        throw new Error('CLS get failure');
       });
       const exception = new DomainError('DO9999', 'Test error');
 
@@ -581,10 +681,14 @@ describe('unit GlobalExceptionFilter', () => {
       consoleSpy.mockRestore();
 
       expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
-      expect(mockResponse.json).toHaveBeenCalledWith({
-        statusCode: HttpStatus.BAD_REQUEST,
-        errorCode: 'DO9999',
-      });
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: `${BASE_URL}/DO9999`,
+          title: 'Unknown domain error.',
+          status: HttpStatus.BAD_REQUEST,
+          errorCode: 'DO9999',
+        }),
+      );
     });
   });
 });

--- a/packages/apps/backend/tests/src/apis/utils/interceptors/tracing.interceptor.spec.ts
+++ b/packages/apps/backend/tests/src/apis/utils/interceptors/tracing.interceptor.spec.ts
@@ -1,0 +1,104 @@
+const mockTrace = jest.fn();
+
+jest.mock<typeof import('dd-trace')>(
+  'dd-trace',
+  () =>
+    ({
+      __esModule: true,
+      default: {
+        trace: mockTrace,
+      },
+    }) as never,
+);
+
+import { type CallHandler, type ExecutionContext } from '@nestjs/common';
+import { of, throwError, firstValueFrom } from 'rxjs';
+
+import { TracingInterceptor } from '@/apis/utils/interceptors/tracing.interceptor';
+
+describe('unit TracingInterceptor', () => {
+  let interceptor: TracingInterceptor;
+  let mockGetClass: jest.Mock;
+  let mockGetHandler: jest.Mock;
+  let mockHandle: jest.Mock;
+  let mockExecutionContext: Partial<ExecutionContext>;
+  let mockCallHandler: Partial<CallHandler>;
+
+  beforeEach(() => {
+    mockTrace.mockClear();
+    interceptor = new TracingInterceptor();
+
+    mockGetClass = jest.fn().mockReturnValue({ name: 'TestController' });
+    mockGetHandler = jest.fn().mockReturnValue({ name: 'testMethod' });
+    mockHandle = jest.fn().mockReturnValue(of({ result: 'test' }));
+
+    mockExecutionContext = {
+      getClass: mockGetClass,
+      getHandler: mockGetHandler,
+    };
+
+    mockCallHandler = {
+      handle: mockHandle,
+    };
+  });
+
+  it('should call tracer.trace with correct span name and resource', async () => {
+    expect.assertions(2);
+
+    mockTrace.mockImplementation((_name: string, _opts: unknown, fn: () => unknown) => fn());
+
+    const result$ = interceptor.intercept(mockExecutionContext as ExecutionContext, mockCallHandler as CallHandler);
+
+    const value = await firstValueFrom(result$);
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      'nestjs.handler',
+      { resource: 'TestController.testMethod' },
+      expect.any(Function),
+    );
+    expect(value).toStrictEqual({ result: 'test' });
+  });
+
+  it('should compose resource name from controller and handler names', async () => {
+    expect.assertions(1);
+
+    mockTrace.mockImplementation((_name: string, _opts: unknown, fn: () => unknown) => fn());
+
+    mockGetClass.mockReturnValue({ name: 'UsersController' });
+    mockGetHandler.mockReturnValue({ name: 'findAll' });
+
+    const result$ = interceptor.intercept(mockExecutionContext as ExecutionContext, mockCallHandler as CallHandler);
+
+    await firstValueFrom(result$);
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      'nestjs.handler',
+      { resource: 'UsersController.findAll' },
+      expect.any(Function),
+    );
+  });
+
+  it('should propagate errors from the handler', async () => {
+    expect.assertions(1);
+
+    const error = new Error('Handler error');
+    mockTrace.mockImplementation((_name: string, _opts: unknown, fn: () => unknown) => fn());
+
+    mockHandle.mockReturnValue(throwError(() => error));
+
+    const result$ = interceptor.intercept(mockExecutionContext as ExecutionContext, mockCallHandler as CallHandler);
+
+    await expect(firstValueFrom(result$)).rejects.toThrow(error);
+  });
+
+  it('should propagate errors from tracer.trace', async () => {
+    expect.assertions(1);
+
+    const error = new Error('Tracer error');
+    mockTrace.mockRejectedValue(error);
+
+    const result$ = interceptor.intercept(mockExecutionContext as ExecutionContext, mockCallHandler as CallHandler);
+
+    await expect(firstValueFrom(result$)).rejects.toThrow(error);
+  });
+});

--- a/packages/apps/backend/tests/src/utils/decorators/trace.decorator.spec.ts
+++ b/packages/apps/backend/tests/src/utils/decorators/trace.decorator.spec.ts
@@ -1,0 +1,135 @@
+const mockTrace = jest.fn();
+
+jest.mock<typeof import('dd-trace')>(
+  'dd-trace',
+  () =>
+    ({
+      __esModule: true,
+      default: {
+        trace: mockTrace,
+      },
+    }) as never,
+);
+
+import { Trace } from '@/utils/decorators/trace.decorator';
+
+describe('unit Trace decorator', () => {
+  beforeEach(() => {
+    mockTrace.mockClear();
+    mockTrace.mockImplementation((_name: string, _opts: unknown, fn: () => unknown) => fn());
+  });
+
+  it('should wrap method with tracer.trace using auto-generated operation name', () => {
+    expect.assertions(2);
+
+    class TestService {
+      @Trace()
+      public execute(): string {
+        return 'result';
+      }
+    }
+
+    const service = new TestService();
+    const result = service.execute();
+
+    expect(result).toBe('result');
+    expect(mockTrace).toHaveBeenCalledWith(
+      'domain.operation',
+      { resource: 'TestService.execute' },
+      expect.any(Function),
+    );
+  });
+
+  it('should use custom operation name when provided', () => {
+    expect.assertions(1);
+
+    class TestService {
+      @Trace('custom.operation')
+      public execute(): string {
+        return 'result';
+      }
+    }
+
+    const service = new TestService();
+    service.execute();
+
+    expect(mockTrace).toHaveBeenCalledWith('domain.operation', { resource: 'custom.operation' }, expect.any(Function));
+  });
+
+  it('should pass through method arguments and return value', () => {
+    expect.assertions(1);
+
+    class TestService {
+      @Trace()
+      public findById(id: string): { id: string; name: string } {
+        return { id, name: 'test' };
+      }
+    }
+
+    const service = new TestService();
+    const result = service.findById('abc-123');
+
+    expect(result).toStrictEqual({ id: 'abc-123', name: 'test' });
+  });
+
+  it('should propagate errors from the original method', () => {
+    expect.assertions(2);
+
+    const error = new Error('Method error');
+
+    class TestService {
+      @Trace()
+      public execute(): never {
+        throw error;
+      }
+    }
+
+    const service = new TestService();
+
+    expect(() => service.execute()).toThrow(error);
+    expect(mockTrace).toHaveBeenCalledWith(
+      'domain.operation',
+      { resource: 'TestService.execute' },
+      expect.any(Function),
+    );
+  });
+
+  it('should work with synchronous methods', () => {
+    expect.assertions(2);
+
+    class TestService {
+      @Trace()
+      public execute(): string {
+        return 'sync-result';
+      }
+    }
+
+    const service = new TestService();
+    const result = service.execute();
+
+    expect(result).toBe('sync-result');
+    expect(mockTrace).toHaveBeenCalledWith(
+      'domain.operation',
+      { resource: 'TestService.execute' },
+      expect.any(Function),
+    );
+  });
+
+  it('should preserve this context in the wrapped method', () => {
+    expect.assertions(1);
+
+    class TestService {
+      private readonly prefix = 'hello';
+
+      @Trace()
+      public greet(name: string): string {
+        return `${this.prefix} ${name}`;
+      }
+    }
+
+    const service = new TestService();
+    const result = service.greet('world');
+
+    expect(result).toBe('hello world');
+  });
+});

--- a/packages/apps/mobile/generated/types/api.d.ts
+++ b/packages/apps/mobile/generated/types/api.d.ts
@@ -126,10 +126,18 @@ export interface components {
             updatedAt: string;
         };
         ErrorResponseDto: {
+            /** @example https://developer.music-practice-tracker.com/errors/AP0400 */
+            type: string;
+            /** @example Bad request. */
+            title: string;
             /** @example 400 */
-            statusCode: number;
-            /** @example RE0002 */
+            status: number;
+            /** @example AP0400 */
             errorCode: string;
+            /** @example req-uuid-xxx */
+            correlationId?: string;
+            /** @example /api/v1/users */
+            instance?: string;
         };
         UpdateUserDataDto: {
             /**


### PR DESCRIPTION
## Summary
- NestJS `TracingInterceptor` + `@Trace()` デコレータで dd-trace カスタムスパンを追加
- DogStatsD ビジネスメトリクス (`app.user.created` / `app.user.deleted`) を追加
- エラーレスポンスを RFC 7807 Problem Details 形式に移行 (`application/problem+json`)

## BREAKING CHANGE
- `ErrorResponseDto.statusCode` → `status` にリネーム（RFC 7807 準拠）
- `type`, `title`, `correlationId`, `instance` フィールドを追加
- admin / mobile の `generated/types/api.d.ts` はバックエンド起動後に `bun run gen:api-types` で再生成が必要

## Changes
| ファイル | 内容 |
|---|---|
| `tracing.interceptor.ts` | コントローラーハンドラーに `nestjs.handler` スパン自動付与 |
| `trace.decorator.ts` | `@Trace()` メソッドデコレータで `domain.operation` スパン付与 |
| `dogstatsd.metrics.ts` | ビジネスメトリクス送信ヘルパー |
| `api.error.ts` | `ErrorResponseDto` を RFC 7807 フィールドに拡張 |
| `global-exception.filter.ts` | RFC 7807 レスポンス生成 + `application/problem+json` |
| `app.module.ts` / `admin.module.ts` | `TracingInterceptor` 登録 |
| `delete-user.service.ts` | `@Trace()` + メトリクス追加 |
| `user.command.service.ts` | メトリクス追加 |

## Test plan
- [ ] `bun run test -- --testPathPatterns=global-exception` — フィルターテスト (38件)
- [ ] `bun run test -- --testPathPatterns=tracing` — インターセプターテスト (4件)
- [ ] `bun run test -- --testPathPatterns=trace.decorator` — デコレータテスト (6件)
- [ ] `bun turbo lint:es:check type:check` — パッケージ品質ゲート
- [ ] `bun run lint:es:check:root && bun run type:check:root` — ルート品質ゲート
- [ ] `bun run format:check` — フォーマットチェック
- [ ] バックエンド起動後、admin / mobile で `bun run gen:api-types` を実行し型再生成を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)