### PR TITLE
feat(backend): add Phase 5A DDD evolution - UpdateUserService + changeName/changeStatus events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ setup:
 	@bin/local/setup-env
 	@${MAKE} setup-dotenv-linter
 	bun install
-	bun run gen:rules
 	@make -C packages/libs/tsconfig-base setup
 	@make -C packages/libs/eslint-configs setup
 	@make -C packages/libs/eslint-configs build

--- a/README.md
+++ b/README.md
@@ -150,44 +150,6 @@ bunx turbo login
 bunx turbo link
 ```
 
-## AI Tool Configuration (RuleSync)
-
-AI coding tool settings (rules, commands, agents, skills) are managed by [RuleSync](https://github.com/dyoshikawa/rulesync). The single source of truth is `.rulesync/` and tool-specific files are auto-generated.
-
-```bash
-# Regenerate all AI tool configs (Claude Code, Cursor, Copilot)
-bun run rulesync
-
-# Preview changes without writing
-bun run rulesync:dry-run
-
-# CI check (exits 1 if out of date)
-bun run rulesync:check
-```
-
-`make setup` automatically runs RuleSync generation (`bun run gen:rules`). RuleSync is installed as an npm devDependency.
-
-### Managed Targets
-
-| Tool           | Generated Files                                       |
-| -------------- | ----------------------------------------------------- |
-| Claude Code    | `CLAUDE.md`, `.claude/`                               |
-| Cursor         | `.cursor/rules/`, `.cursor/commands/`, etc            |
-| GitHub Copilot | `.github/copilot-instructions.md`, `.github/prompts/` |
-
-### Editing Rules
-
-Edit files in `.rulesync/` (not the generated files), then run `bun run rulesync`.
-
-| What     | Location                    |
-| -------- | --------------------------- |
-| Rules    | `.rulesync/rules/CLAUDE.md` |
-| Commands | `.rulesync/commands/`       |
-| Agents   | `.rulesync/subagents/`      |
-| Skills   | `.rulesync/skills/`         |
-| MCP      | `.rulesync/mcp.json`        |
-| Ignore   | `.rulesync/.aiignore`       |
-
 ## License
 
 Proprietary software. See [LICENSE](./LICENSE). For inquiries: <takuya.iwashiro@takudev.net>

--- a/packages/apps/backend/src/apis/admin/users/users.controller.ts
+++ b/packages/apps/backend/src/apis/admin/users/users.controller.ts
@@ -14,6 +14,7 @@ import {
   UserResponseDto,
   UsersResponseDto,
 } from '@/domain/aggregates/user/utils/dto';
+import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
 
 @ApiTags('users')
 @ApiController('users')
@@ -21,6 +22,7 @@ export class AdminApiUsersController {
   public constructor(
     private readonly userQuery: UserQueryService,
     private readonly userCommand: UserCommandService,
+    private readonly updateUserService: UpdateUserService,
   ) {}
 
   @Get()
@@ -91,7 +93,7 @@ export class AdminApiUsersController {
     @Param('publicId', new ParseUUIDPipe()) publicId: string,
     @Body() data: UpdateUserDataDto,
   ): Promise<UserResponseDto> {
-    return this.userCommand.updateUserById({ publicId, data });
+    return this.updateUserService.execute(publicId, data);
   }
 
   @Delete(':publicId')

--- a/packages/apps/backend/src/apis/admin/users/users.module.ts
+++ b/packages/apps/backend/src/apis/admin/users/users.module.ts
@@ -3,9 +3,11 @@ import { Module } from '@nestjs/common';
 import { AdminApiUsersController } from './users.controller';
 
 import { UserModule } from '@/domain/aggregates/user/user.module';
+import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
 
 @Module({
   imports: [UserModule],
+  providers: [UpdateUserService],
   controllers: [AdminApiUsersController],
 })
 export class AdminUsersModule {}

--- a/packages/apps/backend/src/apis/app/users/users.controller.ts
+++ b/packages/apps/backend/src/apis/app/users/users.controller.ts
@@ -13,6 +13,7 @@ import { UserCommandService } from '@/domain/aggregates/user/user.command.servic
 import { UserQueryService } from '@/domain/aggregates/user/user.query.service';
 import { CreateUserInputDto, UpdateUserDataDto, UserResponseDto } from '@/domain/aggregates/user/utils/dto';
 import { DeleteUserService } from '@/domain/usecases/user/delete-user.service';
+import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
 import { FirebaseAuthService } from '@/firebase-auth/firebase-auth.service';
 import { isProviderAllowed } from '@/firebase-auth/utils/constants';
 
@@ -24,6 +25,7 @@ export class AppApiUsersController {
     private readonly userQueryService: UserQueryService,
     private readonly userCommandService: UserCommandService,
     private readonly deleteUserService: DeleteUserService,
+    private readonly updateUserService: UpdateUserService,
   ) {}
 
   @Post()
@@ -78,7 +80,7 @@ export class AppApiUsersController {
     @CurrentUser() user: CurrentUserData,
     @Body() data: UpdateUserDataDto,
   ): Promise<UserResponseDto> {
-    return this.userCommandService.updateUserById({ publicId: user.publicId, data });
+    return this.updateUserService.execute(user.publicId, data);
   }
 
   @Delete('me')

--- a/packages/apps/backend/src/apis/app/users/users.module.ts
+++ b/packages/apps/backend/src/apis/app/users/users.module.ts
@@ -4,10 +4,11 @@ import { AppApiUsersController } from './users.controller';
 
 import { UserModule } from '@/domain/aggregates/user/user.module';
 import { DeleteUserService } from '@/domain/usecases/user/delete-user.service';
+import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
 
 @Module({
   imports: [UserModule],
-  providers: [DeleteUserService],
+  providers: [DeleteUserService, UpdateUserService],
   controllers: [AppApiUsersController],
 })
 export class AppApiUsersModule {}

--- a/packages/apps/backend/src/domain/aggregates/user/event-handlers/user-metrics.handler.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/event-handlers/user-metrics.handler.ts
@@ -5,6 +5,10 @@ import { USER_CREATED_EVENT } from '../events/user-created.event';
 import type { UserCreatedEvent } from '../events/user-created.event';
 import { USER_DELETED_EVENT } from '../events/user-deleted.event';
 import type { UserDeletedEvent } from '../events/user-deleted.event';
+import { USER_NAME_CHANGED_EVENT } from '../events/user-name-changed.event';
+import type { UserNameChangedEvent } from '../events/user-name-changed.event';
+import { USER_STATUS_CHANGED_EVENT } from '../events/user-status-changed.event';
+import type { UserStatusChangedEvent } from '../events/user-status-changed.event';
 
 import { Metrics } from '@/utils/metrics/dogstatsd.metrics';
 
@@ -30,6 +34,28 @@ export class UserMetricsHandler {
     } catch (error: unknown) {
       this.logger.warn(
         `Failed to record ${USER_DELETED_EVENT} metric (aggregateId=${event.aggregateId}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  @OnEvent(USER_NAME_CHANGED_EVENT)
+  public handleUserNameChanged(event: UserNameChangedEvent): void {
+    try {
+      Metrics.incrementUserNameChanged();
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Failed to record ${USER_NAME_CHANGED_EVENT} metric (aggregateId=${event.aggregateId}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  @OnEvent(USER_STATUS_CHANGED_EVENT)
+  public handleUserStatusChanged(event: UserStatusChangedEvent): void {
+    try {
+      Metrics.incrementUserStatusChanged();
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Failed to record ${USER_STATUS_CHANGED_EVENT} metric (aggregateId=${event.aggregateId}): ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/packages/apps/backend/src/domain/aggregates/user/events/index.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/events/index.ts
@@ -1,2 +1,4 @@
 export { USER_CREATED_EVENT, UserCreatedEvent } from './user-created.event';
 export { USER_DELETED_EVENT, UserDeletedEvent } from './user-deleted.event';
+export { USER_NAME_CHANGED_EVENT, UserNameChangedEvent } from './user-name-changed.event';
+export { USER_STATUS_CHANGED_EVENT, UserStatusChangedEvent } from './user-status-changed.event';

--- a/packages/apps/backend/src/domain/aggregates/user/events/user-name-changed.event.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/events/user-name-changed.event.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from '@/domain/utils/domain-event.base';
+
+export const USER_NAME_CHANGED_EVENT = 'user.name_changed' as const;
+
+export class UserNameChangedEvent extends DomainEvent {
+  public readonly eventName = USER_NAME_CHANGED_EVENT;
+
+  public constructor(
+    aggregateId: string,
+    public readonly oldName: string,
+    public readonly newName: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/packages/apps/backend/src/domain/aggregates/user/events/user-status-changed.event.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/events/user-status-changed.event.ts
@@ -1,0 +1,15 @@
+import { DomainEvent } from '@/domain/utils/domain-event.base';
+
+export const USER_STATUS_CHANGED_EVENT = 'user.status_changed' as const;
+
+export class UserStatusChangedEvent extends DomainEvent {
+  public readonly eventName = USER_STATUS_CHANGED_EVENT;
+
+  public constructor(
+    aggregateId: string,
+    public readonly oldStatus: string,
+    public readonly newStatus: string,
+  ) {
+    super(aggregateId);
+  }
+}

--- a/packages/apps/backend/src/domain/aggregates/user/events/user-status-changed.event.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/events/user-status-changed.event.ts
@@ -1,4 +1,5 @@
 import { DomainEvent } from '@/domain/utils/domain-event.base';
+import type { UserStatusValue } from '@/domain/utils/value-objects/user-status.vo';
 
 export const USER_STATUS_CHANGED_EVENT = 'user.status_changed' as const;
 
@@ -7,8 +8,8 @@ export class UserStatusChangedEvent extends DomainEvent {
 
   public constructor(
     aggregateId: string,
-    public readonly oldStatus: string,
-    public readonly newStatus: string,
+    public readonly oldStatus: UserStatusValue,
+    public readonly newStatus: UserStatusValue,
   ) {
     super(aggregateId);
   }

--- a/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
@@ -1,4 +1,4 @@
-import { UserCreatedEvent, UserDeletedEvent } from './events';
+import { UserCreatedEvent, UserDeletedEvent, UserNameChangedEvent, UserStatusChangedEvent } from './events';
 
 import { AggregateRoot } from '@/domain/utils/aggregate-root.base';
 import { toUserPublicId } from '@/domain/utils/brand-constructors';
@@ -62,12 +62,16 @@ export class UserAggregate extends AggregateRoot<UserProps, UserPublicId> {
   }
 
   public changeName(newName: UserName): void {
+    const oldName = this.props.name.value;
     this.props = { ...this.props, name: newName };
+    this.addDomainEvent(new UserNameChangedEvent(this.publicId, oldName, newName.value));
   }
 
   public changeStatus(newStatus: UserStatus): void {
     this.validateStatusTransition(this.props.status, newStatus);
+    const oldStatus = this.props.status.value;
     this.props = { ...this.props, status: newStatus };
+    this.addDomainEvent(new UserStatusChangedEvent(this.publicId, oldStatus, newStatus.value));
   }
 
   public get name(): UserName {

--- a/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
@@ -89,8 +89,9 @@ export class UserAggregate extends AggregateRoot<UserProps, UserPublicId> {
   }
 
   /**
-   * Status transition rules:
-   * - BANNED is a terminal state (transitions out of BANNED are forbidden; BANNED -> BANNED passes validation)
+   * Status transition rules (called only when current !== next due to
+   * same-value guard in changeStatus):
+   * - BANNED is a terminal state; transitions from BANNED to any other status are forbidden
    * - All other transitions between ACTIVE, PENDING, and SUSPENDED are unrestricted
    */
   private validateStatusTransition(current: UserStatus, next: UserStatus): void {

--- a/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
+++ b/packages/apps/backend/src/domain/aggregates/user/user.aggregate.ts
@@ -62,12 +62,14 @@ export class UserAggregate extends AggregateRoot<UserProps, UserPublicId> {
   }
 
   public changeName(newName: UserName): void {
+    if (this.props.name.equals(newName)) return;
     const oldName = this.props.name.value;
     this.props = { ...this.props, name: newName };
     this.addDomainEvent(new UserNameChangedEvent(this.publicId, oldName, newName.value));
   }
 
   public changeStatus(newStatus: UserStatus): void {
+    if (this.props.status.equals(newStatus)) return;
     this.validateStatusTransition(this.props.status, newStatus);
     const oldStatus = this.props.status.value;
     this.props = { ...this.props, status: newStatus };

--- a/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
+++ b/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
@@ -28,17 +28,17 @@ export class UpdateUserService {
       status: user.status,
     });
 
+    const updateData: UpdateUserDataDto = {};
+
     if (data.name !== undefined) {
       aggregate.changeName(UserName.create(data.name));
+      updateData.name = aggregate.name.value;
     }
 
     if (data.status !== undefined) {
       aggregate.changeStatus(UserStatus.create(data.status));
+      updateData.status = aggregate.status.value;
     }
-
-    const updateData: UpdateUserDataDto = {};
-    if (data.name !== undefined) updateData.name = aggregate.name.value;
-    if (data.status !== undefined) updateData.status = aggregate.status.value;
 
     const result = await this.usersCommand.updateUserById({ publicId, data: updateData });
 

--- a/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
+++ b/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+
+import { UserAggregate } from '@/domain/aggregates/user/user.aggregate';
+import { UserCommandService } from '@/domain/aggregates/user/user.command.service';
+import { UserQueryService } from '@/domain/aggregates/user/user.query.service';
+import type { UpdateUserDataDto, UserResponseDto } from '@/domain/aggregates/user/utils/dto';
+import { DomainEventPublisher } from '@/domain/utils/domain-event-publisher.service';
+import { UserName } from '@/domain/utils/value-objects/user-name.vo';
+import { UserStatus } from '@/domain/utils/value-objects/user-status.vo';
+import { Trace } from '@/utils/decorators/trace.decorator';
+
+@Injectable()
+export class UpdateUserService {
+  public constructor(
+    private readonly usersQuery: UserQueryService,
+    private readonly usersCommand: UserCommandService,
+    private readonly eventPublisher: DomainEventPublisher,
+  ) {}
+
+  @Trace()
+  public async execute(publicId: string, data: UpdateUserDataDto): Promise<UserResponseDto> {
+    const user = await this.usersQuery.findUniqueOrThrowUserById({ publicId });
+
+    const aggregate = UserAggregate.fromPersistence({
+      publicId: user.publicId,
+      name: user.name,
+      firebaseUid: user.firebaseUid,
+      status: user.status,
+    });
+
+    if (data.name !== undefined) {
+      aggregate.changeName(UserName.create(data.name));
+    }
+
+    if (data.status !== undefined) {
+      aggregate.changeStatus(UserStatus.create(data.status));
+    }
+
+    const result = await this.usersCommand.updateUserById({ publicId, data });
+
+    this.eventPublisher.publishAll(aggregate);
+
+    return result;
+  }
+}

--- a/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
+++ b/packages/apps/backend/src/domain/usecases/user/update-user.service.ts
@@ -36,7 +36,11 @@ export class UpdateUserService {
       aggregate.changeStatus(UserStatus.create(data.status));
     }
 
-    const result = await this.usersCommand.updateUserById({ publicId, data });
+    const updateData: UpdateUserDataDto = {};
+    if (data.name !== undefined) updateData.name = aggregate.name.value;
+    if (data.status !== undefined) updateData.status = aggregate.status.value;
+
+    const result = await this.usersCommand.updateUserById({ publicId, data: updateData });
 
     this.eventPublisher.publishAll(aggregate);
 

--- a/packages/apps/backend/src/domain/usecases/user/user-usecase.module.ts
+++ b/packages/apps/backend/src/domain/usecases/user/user-usecase.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { DeleteUserService } from './delete-user.service';
+import { UpdateUserService } from './update-user.service';
 
 import { UserModule } from '@/domain/aggregates/user/user.module';
 import { FirebaseAuthModule } from '@/firebase-auth/firebase-auth.module';
 
 @Module({
   imports: [FirebaseAuthModule, UserModule],
-  providers: [DeleteUserService],
-  exports: [DeleteUserService],
+  providers: [DeleteUserService, UpdateUserService],
+  exports: [DeleteUserService, UpdateUserService],
 })
 export class UserUsecaseModule {}

--- a/packages/apps/backend/src/domain/utils/domain-event-publisher.service.ts
+++ b/packages/apps/backend/src/domain/utils/domain-event-publisher.service.ts
@@ -9,6 +9,12 @@ export class DomainEventPublisher {
 
   public constructor(private readonly eventEmitter: EventEmitter2) {}
 
+  /**
+   * Publish all pending domain events from the aggregate using synchronous
+   * fire-and-forget semantics. Event handler failures are caught and logged
+   * but never propagate to callers. Events are pulled (consumed) from the
+   * aggregate, so calling this method twice yields no duplicate emissions.
+   */
   public publishAll(aggregate: AggregateRoot<unknown>): void {
     const events = aggregate.pullDomainEvents();
     for (const event of events) {

--- a/packages/apps/backend/src/domain/utils/entity.base.ts
+++ b/packages/apps/backend/src/domain/utils/entity.base.ts
@@ -1,5 +1,11 @@
 export abstract class Entity<TProps, TId extends string = string> {
   protected readonly _publicId: TId;
+  /**
+   * Not `readonly` by design — aggregates reassign `this.props` via spread
+   * (`this.props = { ...this.props, … }`) to apply state transitions while
+   * keeping each mutation explicit. Value-object immutability is enforced
+   * separately by `Object.freeze` inside each VO.
+   */
   protected props: TProps;
 
   protected constructor(publicId: TId, props: TProps) {

--- a/packages/apps/backend/src/domain/utils/value-objects/user-status.vo.ts
+++ b/packages/apps/backend/src/domain/utils/value-objects/user-status.vo.ts
@@ -3,7 +3,7 @@ import { ValueObject } from '../value-object.base';
 import { DomainError } from '@/domain/utils/domain.error';
 
 const VALID_STATUSES = ['ACTIVE', 'PENDING', 'SUSPENDED', 'BANNED'] as const;
-type UserStatusValue = (typeof VALID_STATUSES)[number];
+export type UserStatusValue = (typeof VALID_STATUSES)[number];
 
 type UserStatusProps = {
   value: UserStatusValue;

--- a/packages/apps/backend/src/utils/metrics/dogstatsd.metrics.ts
+++ b/packages/apps/backend/src/utils/metrics/dogstatsd.metrics.ts
@@ -7,4 +7,10 @@ export const Metrics = {
   incrementUserDeleted: (): void => {
     tracer.dogstatsd.increment('app.user.deleted');
   },
+  incrementUserNameChanged: (): void => {
+    tracer.dogstatsd.increment('app.user.name_changed');
+  },
+  incrementUserStatusChanged: (): void => {
+    tracer.dogstatsd.increment('app.user.status_changed');
+  },
 } as const;

--- a/packages/apps/backend/tests/src/domain/aggregates/user/event-handlers/user-metrics.handler.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/event-handlers/user-metrics.handler.spec.ts
@@ -129,4 +129,72 @@ describe('unit UserMetricsHandler', () => {
     expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('metrics failure'));
     expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('agg-101'));
   });
+
+  it('should stringify non-Error thrown value in handleUserCreated', () => {
+    expect.assertions(2);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserCreated').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'non-error failure';
+    });
+
+    const event = new UserCreatedEvent('agg-123', 'Takuya', 'firebase-uid-1');
+
+    expect(() => {
+      handler.handleUserCreated(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('non-error failure'));
+  });
+
+  it('should stringify non-Error thrown value in handleUserDeleted', () => {
+    expect.assertions(2);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserDeleted').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'non-error failure';
+    });
+
+    const event = new UserDeletedEvent('agg-456');
+
+    expect(() => {
+      handler.handleUserDeleted(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('non-error failure'));
+  });
+
+  it('should stringify non-Error thrown value in handleUserNameChanged', () => {
+    expect.assertions(2);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserNameChanged').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'non-error failure';
+    });
+
+    const event = new UserNameChangedEvent('agg-789', 'OldName', 'NewName');
+
+    expect(() => {
+      handler.handleUserNameChanged(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('non-error failure'));
+  });
+
+  it('should stringify non-Error thrown value in handleUserStatusChanged', () => {
+    expect.assertions(2);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserStatusChanged').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'non-error failure';
+    });
+
+    const event = new UserStatusChangedEvent('agg-101', 'ACTIVE', 'BANNED');
+
+    expect(() => {
+      handler.handleUserStatusChanged(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('non-error failure'));
+  });
 });

--- a/packages/apps/backend/tests/src/domain/aggregates/user/event-handlers/user-metrics.handler.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/event-handlers/user-metrics.handler.spec.ts
@@ -3,6 +3,8 @@ import { Logger } from '@nestjs/common';
 import { UserMetricsHandler } from '@/domain/aggregates/user/event-handlers/user-metrics.handler';
 import { UserCreatedEvent } from '@/domain/aggregates/user/events/user-created.event';
 import { UserDeletedEvent } from '@/domain/aggregates/user/events/user-deleted.event';
+import { UserNameChangedEvent } from '@/domain/aggregates/user/events/user-name-changed.event';
+import { UserStatusChangedEvent } from '@/domain/aggregates/user/events/user-status-changed.event';
 import { Metrics } from '@/utils/metrics/dogstatsd.metrics';
 
 describe('unit UserMetricsHandler', () => {
@@ -12,6 +14,8 @@ describe('unit UserMetricsHandler', () => {
     handler = new UserMetricsHandler();
     jest.spyOn(Metrics, 'incrementUserCreated').mockReturnValue(undefined);
     jest.spyOn(Metrics, 'incrementUserDeleted').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserNameChanged').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserStatusChanged').mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -36,6 +40,26 @@ describe('unit UserMetricsHandler', () => {
     handler.handleUserDeleted(event);
 
     expect(Metrics.incrementUserDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call Metrics.incrementUserNameChanged on user.name_changed event', () => {
+    expect.assertions(1);
+
+    const event = new UserNameChangedEvent('agg-123', 'OldName', 'NewName');
+
+    handler.handleUserNameChanged(event);
+
+    expect(Metrics.incrementUserNameChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call Metrics.incrementUserStatusChanged on user.status_changed event', () => {
+    expect.assertions(1);
+
+    const event = new UserStatusChangedEvent('agg-123', 'ACTIVE', 'SUSPENDED');
+
+    handler.handleUserStatusChanged(event);
+
+    expect(Metrics.incrementUserStatusChanged).toHaveBeenCalledTimes(1);
   });
 
   it('should catch and log error with aggregateId when incrementUserCreated throws', () => {
@@ -70,5 +94,39 @@ describe('unit UserMetricsHandler', () => {
     }).not.toThrow();
     expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('metrics failure'));
     expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('agg-456'));
+  });
+
+  it('should catch and log error with aggregateId when incrementUserNameChanged throws', () => {
+    expect.assertions(3);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserNameChanged').mockImplementation(() => {
+      throw new Error('metrics failure');
+    });
+
+    const event = new UserNameChangedEvent('agg-789', 'OldName', 'NewName');
+
+    expect(() => {
+      handler.handleUserNameChanged(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('metrics failure'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('agg-789'));
+  });
+
+  it('should catch and log error with aggregateId when incrementUserStatusChanged throws', () => {
+    expect.assertions(3);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn').mockReturnValue(undefined);
+    jest.spyOn(Metrics, 'incrementUserStatusChanged').mockImplementation(() => {
+      throw new Error('metrics failure');
+    });
+
+    const event = new UserStatusChangedEvent('agg-101', 'ACTIVE', 'BANNED');
+
+    expect(() => {
+      handler.handleUserStatusChanged(event);
+    }).not.toThrow();
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('metrics failure'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('agg-101'));
   });
 });

--- a/packages/apps/backend/tests/src/domain/aggregates/user/events/user-name-changed.event.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/events/user-name-changed.event.spec.ts
@@ -1,0 +1,40 @@
+import { USER_NAME_CHANGED_EVENT, UserNameChangedEvent } from '@/domain/aggregates/user/events/user-name-changed.event';
+
+describe('unit UserNameChangedEvent', () => {
+  it('should set eventName to the USER_NAME_CHANGED_EVENT constant', () => {
+    expect.assertions(2);
+
+    const event = new UserNameChangedEvent('agg-123', 'OldName', 'NewName');
+
+    expect(event.eventName).toBe('user.name_changed');
+    expect(event.eventName).toBe(USER_NAME_CHANGED_EVENT);
+  });
+
+  it('should store aggregateId', () => {
+    expect.assertions(1);
+
+    const event = new UserNameChangedEvent('agg-123', 'OldName', 'NewName');
+
+    expect(event.aggregateId).toBe('agg-123');
+  });
+
+  it('should store oldName and newName', () => {
+    expect.assertions(2);
+
+    const event = new UserNameChangedEvent('agg-123', 'OldName', 'NewName');
+
+    expect(event.oldName).toBe('OldName');
+    expect(event.newName).toBe('NewName');
+  });
+
+  it('should set occurredAt to current time', () => {
+    expect.assertions(2);
+
+    const before = new Date();
+    const event = new UserNameChangedEvent('agg-123', 'OldName', 'NewName');
+    const after = new Date();
+
+    expect(event.occurredAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(event.occurredAt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+});

--- a/packages/apps/backend/tests/src/domain/aggregates/user/events/user-status-changed.event.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/events/user-status-changed.event.spec.ts
@@ -1,0 +1,43 @@
+import {
+  USER_STATUS_CHANGED_EVENT,
+  UserStatusChangedEvent,
+} from '@/domain/aggregates/user/events/user-status-changed.event';
+
+describe('unit UserStatusChangedEvent', () => {
+  it('should set eventName to the USER_STATUS_CHANGED_EVENT constant', () => {
+    expect.assertions(2);
+
+    const event = new UserStatusChangedEvent('agg-123', 'ACTIVE', 'SUSPENDED');
+
+    expect(event.eventName).toBe('user.status_changed');
+    expect(event.eventName).toBe(USER_STATUS_CHANGED_EVENT);
+  });
+
+  it('should store aggregateId', () => {
+    expect.assertions(1);
+
+    const event = new UserStatusChangedEvent('agg-123', 'ACTIVE', 'SUSPENDED');
+
+    expect(event.aggregateId).toBe('agg-123');
+  });
+
+  it('should store oldStatus and newStatus', () => {
+    expect.assertions(2);
+
+    const event = new UserStatusChangedEvent('agg-123', 'ACTIVE', 'SUSPENDED');
+
+    expect(event.oldStatus).toBe('ACTIVE');
+    expect(event.newStatus).toBe('SUSPENDED');
+  });
+
+  it('should set occurredAt to current time', () => {
+    expect.assertions(2);
+
+    const before = new Date();
+    const event = new UserStatusChangedEvent('agg-123', 'ACTIVE', 'SUSPENDED');
+    const after = new Date();
+
+    expect(event.occurredAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(event.occurredAt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+});

--- a/packages/apps/backend/tests/src/domain/aggregates/user/user.aggregate.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/user.aggregate.spec.ts
@@ -1,4 +1,6 @@
 import type { UserCreatedEvent } from '@/domain/aggregates/user/events/user-created.event';
+import type { UserNameChangedEvent } from '@/domain/aggregates/user/events/user-name-changed.event';
+import type { UserStatusChangedEvent } from '@/domain/aggregates/user/events/user-status-changed.event';
 import { UserAggregate } from '@/domain/aggregates/user/user.aggregate';
 import { DomainError } from '@/domain/utils/domain.error';
 
@@ -165,6 +167,30 @@ describe('unit UserAggregate', () => {
 
       expect(aggregate.name.value).toBe('Alice');
     });
+
+    it('should emit UserNameChangedEvent with oldName and newName', () => {
+      expect.assertions(4);
+
+      const { UserName } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-name.vo')>(
+        '@/domain/utils/value-objects/user-name.vo',
+      );
+      const aggregate = UserAggregate.fromPersistence({
+        publicId: validUuid,
+        name: 'Takuya',
+        firebaseUid: 'firebase-uid-1',
+        status: 'ACTIVE',
+      });
+
+      aggregate.changeName(UserName.create('Alice'));
+
+      const events = aggregate.pullDomainEvents();
+      const event = events[0] as UserNameChangedEvent;
+
+      expect(events).toHaveLength(1);
+      expect(event.eventName).toBe('user.name_changed');
+      expect(event.oldName).toBe('Takuya');
+      expect(event.newName).toBe('Alice');
+    });
   });
 
   describe('changeStatus', () => {
@@ -184,6 +210,30 @@ describe('unit UserAggregate', () => {
       aggregate.changeStatus(UserStatus.create('SUSPENDED'));
 
       expect(aggregate.status.value).toBe('SUSPENDED');
+    });
+
+    it('should emit UserStatusChangedEvent with oldStatus and newStatus', () => {
+      expect.assertions(4);
+
+      const { UserStatus } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-status.vo')>(
+        '@/domain/utils/value-objects/user-status.vo',
+      );
+      const aggregate = UserAggregate.fromPersistence({
+        publicId: validUuid,
+        name: 'Takuya',
+        firebaseUid: 'firebase-uid-1',
+        status: 'ACTIVE',
+      });
+
+      aggregate.changeStatus(UserStatus.create('SUSPENDED'));
+
+      const events = aggregate.pullDomainEvents();
+      const event = events[0] as UserStatusChangedEvent;
+
+      expect(events).toHaveLength(1);
+      expect(event.eventName).toBe('user.status_changed');
+      expect(event.oldStatus).toBe('ACTIVE');
+      expect(event.newStatus).toBe('SUSPENDED');
     });
 
     it.each(['ACTIVE', 'PENDING', 'SUSPENDED'] as const)(
@@ -206,6 +256,26 @@ describe('unit UserAggregate', () => {
         }).toThrow(DomainError);
       },
     );
+
+    it('should not emit event when BANNED to non-BANNED transition fails', () => {
+      expect.assertions(2);
+
+      const { UserStatus } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-status.vo')>(
+        '@/domain/utils/value-objects/user-status.vo',
+      );
+      const aggregate = UserAggregate.fromPersistence({
+        publicId: validUuid,
+        name: 'Takuya',
+        firebaseUid: 'firebase-uid-1',
+        status: 'BANNED',
+      });
+
+      expect(() => {
+        aggregate.changeStatus(UserStatus.create('ACTIVE'));
+      }).toThrow(DomainError);
+
+      expect(aggregate.domainEvents).toHaveLength(0);
+    });
 
     it('should allow BANNED to BANNED (no-op transition)', () => {
       expect.assertions(1);

--- a/packages/apps/backend/tests/src/domain/aggregates/user/user.aggregate.spec.ts
+++ b/packages/apps/backend/tests/src/domain/aggregates/user/user.aggregate.spec.ts
@@ -191,6 +191,25 @@ describe('unit UserAggregate', () => {
       expect(event.oldName).toBe('Takuya');
       expect(event.newName).toBe('Alice');
     });
+
+    it('should not emit event when name is unchanged', () => {
+      expect.assertions(2);
+
+      const { UserName } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-name.vo')>(
+        '@/domain/utils/value-objects/user-name.vo',
+      );
+      const aggregate = UserAggregate.fromPersistence({
+        publicId: validUuid,
+        name: 'Takuya',
+        firebaseUid: 'firebase-uid-1',
+        status: 'ACTIVE',
+      });
+
+      aggregate.changeName(UserName.create('Takuya'));
+
+      expect(aggregate.name.value).toBe('Takuya');
+      expect(aggregate.domainEvents).toHaveLength(0);
+    });
   });
 
   describe('changeStatus', () => {
@@ -277,8 +296,27 @@ describe('unit UserAggregate', () => {
       expect(aggregate.domainEvents).toHaveLength(0);
     });
 
-    it('should allow BANNED to BANNED (no-op transition)', () => {
-      expect.assertions(1);
+    it('should not emit event when status is unchanged (same-value guard)', () => {
+      expect.assertions(2);
+
+      const { UserStatus } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-status.vo')>(
+        '@/domain/utils/value-objects/user-status.vo',
+      );
+      const aggregate = UserAggregate.fromPersistence({
+        publicId: validUuid,
+        name: 'Takuya',
+        firebaseUid: 'firebase-uid-1',
+        status: 'ACTIVE',
+      });
+
+      aggregate.changeStatus(UserStatus.create('ACTIVE'));
+
+      expect(aggregate.status.value).toBe('ACTIVE');
+      expect(aggregate.domainEvents).toHaveLength(0);
+    });
+
+    it('should not emit event for BANNED to BANNED (same-value guard)', () => {
+      expect.assertions(2);
 
       const { UserStatus } = jest.requireActual<typeof import('@/domain/utils/value-objects/user-status.vo')>(
         '@/domain/utils/value-objects/user-status.vo',
@@ -293,6 +331,7 @@ describe('unit UserAggregate', () => {
       aggregate.changeStatus(UserStatus.create('BANNED'));
 
       expect(aggregate.status.value).toBe('BANNED');
+      expect(aggregate.domainEvents).toHaveLength(0);
     });
   });
 });

--- a/packages/apps/backend/tests/src/domain/usecases/user/delete-user.service.spec.ts
+++ b/packages/apps/backend/tests/src/domain/usecases/user/delete-user.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { UserCommandService } from '@/domain/aggregates/user/user.command.service';
@@ -95,6 +96,48 @@ describe('integration DeleteUserService', () => {
 
       await expect(deleteUserService.execute(missingPublicId)).rejects.toThrow('No record was found for a query');
       expect(firebaseAuthService.deleteUser).not.toHaveBeenCalled();
+      expect(eventPublisher.publishAll).not.toHaveBeenCalled();
+    });
+
+    it('logs inconsistent state and re-throws when DB deletion fails after Firebase deletion', async () => {
+      expect.assertions(4);
+
+      const createDto = {
+        name: 'DB Fail User',
+        firebaseUid: 'uid-int-db-fail',
+      };
+
+      const createdUser = await userCommandService.createUser(createDto);
+      eventPublisher.publishAll.mockClear();
+
+      const dbError = new Error('DB connection lost');
+      jest.spyOn(userCommandService, 'deleteUserById').mockRejectedValueOnce(dbError);
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockReturnValue(undefined);
+
+      await expect(deleteUserService.execute(createdUser.publicId)).rejects.toThrow('DB connection lost');
+
+      expect(firebaseAuthService.deleteUser).toHaveBeenCalledWith(createDto.firebaseUid);
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('INCONSISTENT STATE'), expect.any(String));
+      expect(eventPublisher.publishAll).not.toHaveBeenCalled();
+    });
+
+    it('handles non-Error thrown value when DB deletion fails', async () => {
+      expect.assertions(3);
+
+      const createDto = {
+        name: 'Non-Error Fail User',
+        firebaseUid: 'uid-int-non-error-fail',
+      };
+
+      const createdUser = await userCommandService.createUser(createDto);
+      eventPublisher.publishAll.mockClear();
+
+      jest.spyOn(userCommandService, 'deleteUserById').mockRejectedValueOnce('raw db failure');
+      const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockReturnValue(undefined);
+
+      await expect(deleteUserService.execute(createdUser.publicId)).rejects.toBe('raw db failure');
+
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('INCONSISTENT STATE'), undefined);
       expect(eventPublisher.publishAll).not.toHaveBeenCalled();
     });
   });

--- a/packages/apps/backend/tests/src/domain/usecases/user/update-user.service.spec.ts
+++ b/packages/apps/backend/tests/src/domain/usecases/user/update-user.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import type { UserNameChangedEvent } from '@/domain/aggregates/user/events/user-name-changed.event';
+import type { UserStatusChangedEvent } from '@/domain/aggregates/user/events/user-status-changed.event';
+import { UserCommandService } from '@/domain/aggregates/user/user.command.service';
+import { UserQueryService } from '@/domain/aggregates/user/user.query.service';
+import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
+import { DomainEventPublisher } from '@/domain/utils/domain-event-publisher.service';
+import { RepositoryService } from '@/repository/repository.service';
+import { DatabaseHelper } from '@/tests/helpers/database.helper';
+
+describe('integration UpdateUserService', () => {
+  let testingModule: TestingModule;
+  let updateUserService: UpdateUserService;
+  let userCommandService: UserCommandService;
+  let userQueryService: UserQueryService;
+  let eventPublisher: { publishAll: jest.Mock };
+  let databaseHelper: DatabaseHelper;
+
+  beforeAll(async () => {
+    databaseHelper = new DatabaseHelper();
+    await databaseHelper.connect();
+  });
+
+  beforeEach(async () => {
+    await databaseHelper.cleanDatabase();
+
+    eventPublisher = { publishAll: jest.fn() };
+
+    testingModule = await Test.createTestingModule({
+      providers: [
+        UpdateUserService,
+        UserCommandService,
+        UserQueryService,
+        {
+          provide: RepositoryService,
+          useValue: databaseHelper.client,
+        },
+        {
+          provide: DomainEventPublisher,
+          useValue: eventPublisher,
+        },
+      ],
+    }).compile();
+
+    updateUserService = testingModule.get(UpdateUserService);
+    userCommandService = testingModule.get(UserCommandService);
+    userQueryService = testingModule.get(UserQueryService);
+  });
+
+  afterEach(async () => {
+    await testingModule.close();
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await databaseHelper.disconnect();
+  });
+
+  describe('execute', () => {
+    it('should update name and publish UserNameChangedEvent', async () => {
+      expect.assertions(5);
+
+      const created = await userCommandService.createUser({
+        name: 'OriginalName',
+        firebaseUid: 'uid-update-name',
+      });
+      eventPublisher.publishAll.mockClear();
+
+      const result = await updateUserService.execute(created.publicId, { name: 'UpdatedName' });
+
+      expect(result.name).toBe('UpdatedName');
+      expect(eventPublisher.publishAll).toHaveBeenCalledTimes(1);
+
+      const [[aggregate]] = eventPublisher.publishAll.mock.calls;
+      const events = aggregate.pullDomainEvents();
+      const [event] = events as [UserNameChangedEvent];
+
+      expect(events).toHaveLength(1);
+      expect(event.eventName).toBe('user.name_changed');
+      expect(event.oldName).toBe('OriginalName');
+    });
+
+    it('should update status and publish UserStatusChangedEvent', async () => {
+      expect.assertions(5);
+
+      const created = await userCommandService.createUser({
+        name: 'StatusUser',
+        firebaseUid: 'uid-update-status',
+      });
+      eventPublisher.publishAll.mockClear();
+
+      const result = await updateUserService.execute(created.publicId, { status: 'SUSPENDED' });
+
+      expect(result.status).toBe('SUSPENDED');
+      expect(eventPublisher.publishAll).toHaveBeenCalledTimes(1);
+
+      const [[aggregate]] = eventPublisher.publishAll.mock.calls;
+      const events = aggregate.pullDomainEvents();
+      const [event] = events as [UserStatusChangedEvent];
+
+      expect(events).toHaveLength(1);
+      expect(event.eventName).toBe('user.status_changed');
+      expect(event.oldStatus).toBe('ACTIVE');
+    });
+
+    it('should update both name and status and publish both events', async () => {
+      expect.assertions(4);
+
+      const created = await userCommandService.createUser({
+        name: 'BothUser',
+        firebaseUid: 'uid-update-both',
+      });
+      eventPublisher.publishAll.mockClear();
+
+      const result = await updateUserService.execute(created.publicId, {
+        name: 'NewBothName',
+        status: 'SUSPENDED',
+      });
+
+      expect(result.name).toBe('NewBothName');
+      expect(result.status).toBe('SUSPENDED');
+      expect(eventPublisher.publishAll).toHaveBeenCalledTimes(1);
+
+      const [[aggregate]] = eventPublisher.publishAll.mock.calls;
+      const events = aggregate.pullDomainEvents();
+
+      expect(events).toHaveLength(2);
+    });
+
+    it('should throw DomainError for BANNED to ACTIVE transition and not persist changes', async () => {
+      expect.assertions(3);
+
+      const created = await userCommandService.createUser({
+        name: 'BannedUser',
+        firebaseUid: 'uid-banned-transition',
+      });
+      await userCommandService.updateUserById({
+        publicId: created.publicId,
+        data: { status: 'BANNED' },
+      });
+      eventPublisher.publishAll.mockClear();
+
+      await expect(updateUserService.execute(created.publicId, { status: 'ACTIVE' })).rejects.toThrow(
+        'BANNED is a terminal state',
+      );
+      expect(eventPublisher.publishAll).not.toHaveBeenCalled();
+
+      const unchanged = await userQueryService.findUniqueOrThrowUserById({ publicId: created.publicId });
+
+      expect(unchanged.status).toBe('BANNED');
+    });
+
+    it('should throw not-found error for non-existent user', async () => {
+      expect.assertions(2);
+
+      const missingPublicId = '00000000-0000-0000-0000-000000000000';
+
+      await expect(updateUserService.execute(missingPublicId, { name: 'Ghost' })).rejects.toThrow(
+        'No record was found for a query',
+      );
+      expect(eventPublisher.publishAll).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/apps/backend/tests/src/domain/utils/domain-event-publisher.service.spec.ts
+++ b/packages/apps/backend/tests/src/domain/utils/domain-event-publisher.service.spec.ts
@@ -105,4 +105,24 @@ describe('unit DomainEventPublisher', () => {
       expect.any(String),
     );
   });
+
+  it('should handle non-Error thrown values with String() fallback', () => {
+    expect.assertions(1);
+
+    const loggerSpy = jest.spyOn(Logger.prototype, 'error').mockReturnValue(undefined);
+    emitter.emit.mockImplementationOnce(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'raw string failure';
+    });
+
+    const aggregate = new FakeAggregate();
+    aggregate.addEvent('user.created', 'agg-456');
+
+    publisher.publishAll(aggregate as unknown as Parameters<DomainEventPublisher['publishAll']>[0]);
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      'Failed to publish domain event: user.created (aggregateId=agg-456): raw string failure',
+      undefined,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Route update operations through `UserAggregate` to enforce domain validation and emit domain events
- Add `UserNameChangedEvent` and `UserStatusChangedEvent` domain events with metrics handlers
- Create `UpdateUserService` usecase following the same pattern as `DeleteUserService`
- Wire both App and Admin controllers to use `UpdateUserService` instead of direct `CommandService`
- Add JSDoc carry-over from Phase 4B review (DomainEventPublisher.publishAll, Entity.props)
- Remove stale RuleSync references from README and Makefile

## Flow change

```
[Before]
Controller → UserCommandService.updateUserById() → Prisma → DB
(No aggregate, no events, no domain validation)

[After]
Controller → UpdateUserService.execute()
  → UserQueryService.findUniqueOrThrowUserById()
  → UserAggregate.fromPersistence()
  → aggregate.changeName() → UserNameChangedEvent
  → aggregate.changeStatus() → UserStatusChangedEvent
  → UserCommandService.updateUserById() → DB
  → DomainEventPublisher.publishAll()
    → UserMetricsHandler → Metrics.increment()
```

## Test plan

- [x] Unit tests for `UserNameChangedEvent` and `UserStatusChangedEvent`
- [x] Aggregate tests: event emission on `changeName`/`changeStatus`, no event on failed transition
- [x] Metrics handler tests: new handlers + error catch paths
- [x] Integration test for `UpdateUserService`: name-only, status-only, both, BANNED transition failure, not-found
- [x] All quality gates pass: lint, type-check, format

🤖 Generated with [Claude Code](https://claude.com/claude-code)