### PR TITLE
feat(backend): Phase 5B - bulk ops, admin delete alignment

### DIFF
--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fix-review
+description: Address /review-pr findings automatically - fix Critical and Important issues, run quality gates, commit, push if PR exists, then re-run /review-pr. Use when asked to "fix review", "address review findings", "resolve review issues", or after receiving a /review-pr summary with actionable issues.
+---
+
+# Fix Review Findings
+
+Address Critical and Important issues from a `/review-pr` summary, then verify the fixes.
+
+## Workflow
+
+1. **Identify Findings to Fix**
+   - Parse the most recent `/review-pr` summary in conversation context
+   - Collect all **Critical** and **Important** issues (skip Suggestions unless user requests)
+   - Order: Critical first, then Important
+   - If no review summary exists, ask the user to run `/review-pr` first
+
+2. **Fix Each Issue**
+   - Read the source file for each issue before editing
+   - Apply the minimum change needed to resolve the issue
+   - Do NOT refactor surrounding code or add unrelated improvements
+   - Track all modified files
+
+3. **Run Quality Gates**
+   ```bash
+   bun turbo lint:es:check type:check
+   bun run lint:es:check:root
+   bun run type:check:root
+   bun run format:check
+   ```
+   - If any gate fails, fix the failure and re-run
+   - Format with `bun run format:write` if only formatting issues remain
+
+4. **Commit**
+   - Stage only the files modified in step 2
+   - Use commit message format: `refactor(<scope>): address review - <brief summary>`
+   - Keep header under 100 chars (commitlint rule)
+
+5. **Push (if PR exists)**
+   - Check: `gh pr view --json state 2>/dev/null`
+   - If PR is open and branch tracks remote, push with `git push`
+   - If force push is needed (after rebase), ask user for confirmation
+   - If no PR, skip this step
+
+6. **Re-run /review-pr**
+   - Invoke the `/review-pr` skill to verify fixes
+   - Report the before/after comparison of issue counts
+
+## Rules
+
+- **Scope discipline**: Fix only what the review identified. No bonus improvements.
+- **Pre-existing issues**: If a finding is flagged as "pre-existing" or outside the PR diff, note it in the commit message but do NOT fix it unless the user explicitly requests.
+- **Suggestions**: Skip by default. Fix only if user passes `--include-suggestions` or explicitly requests.
+- **Test assertions**: When fixing source code, update corresponding test assertions to match.
+- **Ambiguous fixes**: If the correct fix is unclear, ask the user before proceeding.

--- a/packages/apps/backend/src/apis/admin/users/users.module.ts
+++ b/packages/apps/backend/src/apis/admin/users/users.module.ts
@@ -2,15 +2,10 @@ import { Module } from '@nestjs/common';
 
 import { AdminApiUsersController } from './users.controller';
 
-import { UserModule } from '@/domain/aggregates/user/user.module';
-import { BulkDeleteUsersService } from '@/domain/usecases/user/bulk-delete-users.service';
-import { DeleteUserService } from '@/domain/usecases/user/delete-user.service';
-import { UpdateUserService } from '@/domain/usecases/user/update-user.service';
-import { FirebaseAuthModule } from '@/firebase-auth/firebase-auth.module';
+import { UserUsecaseModule } from '@/domain/usecases/user/user-usecase.module';
 
 @Module({
-  imports: [FirebaseAuthModule, UserModule],
-  providers: [BulkDeleteUsersService, DeleteUserService, UpdateUserService],
+  imports: [UserUsecaseModule],
   controllers: [AdminApiUsersController],
 })
 export class AdminUsersModule {}

--- a/packages/apps/backend/src/apis/utils/filters/global-exception.filter.ts
+++ b/packages/apps/backend/src/apis/utils/filters/global-exception.filter.ts
@@ -214,7 +214,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
   private handleFirebaseError(exception: FirebaseError): ErrorResponseDto {
     const { errorCode } = exception;
-    let status = HttpStatus.UNAUTHORIZED;
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
 
     switch (errorCode) {
       case 'FB0001':
@@ -239,7 +239,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         break;
       default: {
         const _exhaustive: never = errorCode;
-        this.logger.warn(`Unmapped Firebase error code: ${String(_exhaustive)}, defaulting to 401`);
+        this.logger.warn(`Unmapped Firebase error code: ${String(_exhaustive)}, defaulting to 500`);
         break;
       }
     }

--- a/packages/apps/backend/src/domain/usecases/user/bulk-delete-users.service.ts
+++ b/packages/apps/backend/src/domain/usecases/user/bulk-delete-users.service.ts
@@ -70,9 +70,9 @@ export class BulkDeleteUsersService {
     } catch (error: unknown) {
       const detail = error instanceof Error ? error.message : String(error);
       this.logger.error(
-        `Firebase batch deletion failed. Some accounts may have been deleted. ` +
+        `Firebase batch deletion failed; no DB records were modified. ` +
           `publicIds=[${matchedPublicIds.join(', ')}], firebaseUids=[${firebaseUids.join(', ')}]. ` +
-          `detail=${detail}. Manual reconciliation may be required.`,
+          `detail=${detail}. Check Firebase console for partial deletions.`,
         error instanceof Error ? error.stack : undefined,
       );
       throw error;

--- a/packages/apps/backend/src/domain/usecases/user/user-usecase.module.ts
+++ b/packages/apps/backend/src/domain/usecases/user/user-usecase.module.ts
@@ -10,6 +10,6 @@ import { FirebaseAuthModule } from '@/firebase-auth/firebase-auth.module';
 @Module({
   imports: [FirebaseAuthModule, UserModule],
   providers: [BulkDeleteUsersService, DeleteUserService, UpdateUserService],
-  exports: [BulkDeleteUsersService, DeleteUserService, UpdateUserService],
+  exports: [BulkDeleteUsersService, DeleteUserService, UpdateUserService, UserModule],
 })
 export class UserUsecaseModule {}

--- a/packages/apps/backend/src/firebase-auth/firebase-auth.service.ts
+++ b/packages/apps/backend/src/firebase-auth/firebase-auth.service.ts
@@ -65,18 +65,23 @@ export class FirebaseAuthService {
       );
     }
 
-    try {
-      const result = await this.provider.auth().deleteUsers(uids);
-      if (result.failureCount > EMPTY) {
-        const errorDetails = result.errors.map((e) => `index=${String(e.index)} error=${e.error.message}`).join('; ');
-        throw new FirebaseError(
-          'FB0009',
-          `${String(result.failureCount)} of ${String(uids.length)} Firebase account(s) failed to delete: ${errorDetails}`,
-        );
-      }
-    } catch (e) {
-      if (e instanceof FirebaseError) throw e;
-      throw new FirebaseError('FB0009', ERROR_CODE_RECORDS.FB0009, e);
+    const result = await this.provider
+      .auth()
+      .deleteUsers(uids)
+      .catch((e: unknown) => {
+        throw new FirebaseError('FB0009', ERROR_CODE_RECORDS.FB0009, e);
+      });
+
+    if (result.failureCount > EMPTY) {
+      const failedDetails = result.errors.map((e) => `index=${String(e.index)} error=${e.error.message}`).join('; ');
+      const failedIndices = new Set(result.errors.map((e) => e.index));
+      const succeededUids = uids.filter((_, i) => !failedIndices.has(i));
+      throw new FirebaseError(
+        'FB0009',
+        `${String(result.failureCount)} of ${String(uids.length)} Firebase account(s) failed to delete. ` +
+          `Failures: [${failedDetails}]. ` +
+          `Successfully deleted UIDs: [${succeededUids.join(', ')}] (${String(result.successCount)} accounts).`,
+      );
     }
   }
 }

--- a/packages/apps/backend/src/firebase-auth/firebase-auth.service.ts
+++ b/packages/apps/backend/src/firebase-auth/firebase-auth.service.ts
@@ -74,13 +74,11 @@ export class FirebaseAuthService {
 
     if (result.failureCount > EMPTY) {
       const failedDetails = result.errors.map((e) => `index=${String(e.index)} error=${e.error.message}`).join('; ');
-      const failedIndices = new Set(result.errors.map((e) => e.index));
-      const succeededUids = uids.filter((_, i) => !failedIndices.has(i));
       throw new FirebaseError(
         'FB0009',
         `${String(result.failureCount)} of ${String(uids.length)} Firebase account(s) failed to delete. ` +
           `Failures: [${failedDetails}]. ` +
-          `Successfully deleted UIDs: [${succeededUids.join(', ')}] (${String(result.successCount)} accounts).`,
+          `${String(result.successCount)} account(s) were successfully deleted.`,
       );
     }
   }

--- a/packages/apps/backend/tests/helpers/firebase-auth-emulator.helper.ts
+++ b/packages/apps/backend/tests/helpers/firebase-auth-emulator.helper.ts
@@ -152,6 +152,17 @@ export class FirebaseAuthEmulatorHelper {
     }
   }
 
+  /**
+   * Look up a Firebase Auth emulator user by UID.
+   * Returns the user record if found, or `undefined` if the account does not exist.
+   */
+  public async getUserByUid(uid: string): Promise<Record<string, unknown> | undefined> {
+    const body = await this.postIdentityToolkit<{ users?: Record<string, unknown>[] }>('accounts:lookup', {
+      localId: [uid],
+    });
+    return body.users?.[0];
+  }
+
   private async postIdentityToolkit<TResponse>(path: string, body: unknown): Promise<TResponse> {
     const response = await fetch(
       `${this.emulatorOrigin}/identitytoolkit.googleapis.com/v1/${path}?key=${FirebaseAuthEmulatorHelper.API_KEY}`,

--- a/packages/apps/backend/tests/helpers/firebase-auth-emulator.helper.ts
+++ b/packages/apps/backend/tests/helpers/firebase-auth-emulator.helper.ts
@@ -155,11 +155,31 @@ export class FirebaseAuthEmulatorHelper {
   /**
    * Look up a Firebase Auth emulator user by UID.
    * Returns the user record if found, or `undefined` if the account does not exist.
+   *
+   * Uses the emulator admin endpoint (`Authorization: Bearer owner`) because the
+   * client API (`?key=`) requires `idToken` and rejects `localId`-only lookups.
    */
   public async getUserByUid(uid: string): Promise<Record<string, unknown> | undefined> {
-    const body = await this.postIdentityToolkit<{ users?: Record<string, unknown>[] }>('accounts:lookup', {
-      localId: [uid],
-    });
+    const response = await fetch(
+      `${this.emulatorOrigin}/identitytoolkit.googleapis.com/v1/projects/${this.projectId}/accounts:lookup`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer owner',
+        },
+        body: JSON.stringify({ localId: [uid] }),
+      },
+    );
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+      throw new Error(
+        `Firebase Auth emulator request failed (accounts:lookup by UID): ${response.status} ${response.statusText} ${responseBody}`,
+      );
+    }
+
+    const body = (await response.json()) as { users?: Record<string, unknown>[] };
     return body.users?.[0];
   }
 

--- a/packages/apps/backend/tests/src/apis/admin/users/users.controller.spec.ts
+++ b/packages/apps/backend/tests/src/apis/admin/users/users.controller.spec.ts
@@ -101,7 +101,7 @@ describe('e2e AdminApiUsersController', () => {
 
   describe('delete /api/users', () => {
     it('deletes multiple users by public IDs', async () => {
-      expect.assertions(4);
+      expect.assertions(6);
 
       const { uid: uid1 } = await firebaseHelper.createVerifiedUser();
       const { uid: uid2 } = await firebaseHelper.createVerifiedUser();
@@ -125,7 +125,7 @@ describe('e2e AdminApiUsersController', () => {
 
       expect(deleteResponse.status).toBe(204);
 
-      // Verify users are deleted
+      // Verify users are deleted from database
       const user1InDatabase = await databaseHelper.client.user.findUnique({ where: { publicId: publicId1 } });
       const user2InDatabase = await databaseHelper.client.user.findUnique({ where: { publicId: publicId2 } });
 
@@ -136,6 +136,13 @@ describe('e2e AdminApiUsersController', () => {
       const fetchResponse = await httpClient.get(`/api/users/${publicId1}`);
 
       expect(fetchResponse.status).toBe(404);
+
+      // Verify Firebase accounts are deleted
+      const firebaseUser1 = await firebaseHelper.getUserByUid(uid1);
+      const firebaseUser2 = await firebaseHelper.getUserByUid(uid2);
+
+      expect(firebaseUser1).toBeUndefined();
+      expect(firebaseUser2).toBeUndefined();
     });
   });
 
@@ -243,7 +250,7 @@ describe('e2e AdminApiUsersController', () => {
 
   describe('delete /api/users/:publicId', () => {
     it('deletes a user by public ID', async () => {
-      expect.assertions(3);
+      expect.assertions(4);
 
       const { uid } = await firebaseHelper.createVerifiedUser();
 
@@ -267,6 +274,11 @@ describe('e2e AdminApiUsersController', () => {
       const userInDatabase = await databaseHelper.client.user.findUnique({ where: { publicId } });
 
       expect(userInDatabase).toBeNull();
+
+      // Verify Firebase account is deleted
+      const firebaseUser = await firebaseHelper.getUserByUid(uid);
+
+      expect(firebaseUser).toBeUndefined();
     });
   });
 });

--- a/packages/apps/backend/tests/src/domain/usecases/user/bulk-delete-users.service.spec.ts
+++ b/packages/apps/backend/tests/src/domain/usecases/user/bulk-delete-users.service.spec.ts
@@ -182,7 +182,7 @@ describe('integration BulkDeleteUsersService', () => {
 
       expect(stillExists.publicId).toBe(users.users[0].publicId);
       expect(stillExists.name).toBe('Firebase Fail 1');
-      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('reconciliation'), expect.any(String));
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('partial deletions'), expect.any(String));
     });
 
     it('logs inconsistent state with user identifiers and re-throws when DB deletion fails after Firebase deletion', async () => {

--- a/packages/apps/backend/tests/src/firebase-auth/firebase-auth.service.spec.ts
+++ b/packages/apps/backend/tests/src/firebase-auth/firebase-auth.service.spec.ts
@@ -241,7 +241,7 @@ describe('integration FirebaseAuthService', () => {
         detail:
           '1 of 2 Firebase account(s) failed to delete. ' +
           'Failures: [index=1 error=internal error]. ' +
-          'Successfully deleted UIDs: [uid-ok] (1 accounts).',
+          '1 account(s) were successfully deleted.',
       });
       expect(authMock.deleteUsers).toHaveBeenCalledWith(['uid-ok', 'uid-fail']);
     });

--- a/packages/apps/backend/tests/src/firebase-auth/firebase-auth.service.spec.ts
+++ b/packages/apps/backend/tests/src/firebase-auth/firebase-auth.service.spec.ts
@@ -238,7 +238,10 @@ describe('integration FirebaseAuthService', () => {
 
       await expect(service.deleteUsers(['uid-ok', 'uid-fail'])).rejects.toMatchObject({
         errorCode: 'FB0009',
-        detail: '1 of 2 Firebase account(s) failed to delete: index=1 error=internal error',
+        detail:
+          '1 of 2 Firebase account(s) failed to delete. ' +
+          'Failures: [index=1 error=internal error]. ' +
+          'Successfully deleted UIDs: [uid-ok] (1 accounts).',
       });
       expect(authMock.deleteUsers).toHaveBeenCalledWith(['uid-ok', 'uid-fail']);
     });


### PR DESCRIPTION
## Summary
- Add bulk user deletion via `BulkDeleteUsersService` with Firebase batch API and domain event publishing
- Align admin single-delete to publish `UserDeletedEvent` through the aggregate
- Add `FB0009` error code and batch-limit guard for Firebase `deleteUsers`
- Extend `GlobalExceptionFilter` to handle batch-limit errors with 422 status
- Add `getUserByUid` emulator helper and Firebase deletion E2E assertions

## Test plan
- [ ] `bun run test -- --testPathPatterns="firebase-auth.service"` — unit tests pass
- [ ] `bun run test -- --testPathPatterns="bulk-delete-users"` — unit tests pass
- [ ] `bun run test -- --testPathPatterns="global-exception"` — unit tests pass
- [ ] `bun run test -- --testPathPatterns="apis/admin/users"` — E2E tests pass (requires Firebase emulator)
- [ ] `bun turbo lint:es:check type:check` — quality gates pass
- [ ] `bun run format:check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)