### PR TITLE
fix(mobile): update Maestro E2E test for dev client

### DIFF
--- a/packages/apps/mobile/tests/e2e/main-e2e.yaml
+++ b/packages/apps/mobile/tests/e2e/main-e2e.yaml
@@ -1,7 +1,7 @@
-appId: host.exp.Exponent
+appId: com.takudev.musicpracticetracker.development
 ---
 - launchApp
-- tapOn: 'music-practice-tracker'
 - assertVisible: 'Welcome!'
 - assertVisible: 'Step 1: Try it'
 - tapOn: 'nav-explore'
+- assertVisible: 'Explore'


### PR DESCRIPTION
## Summary
- Maestro E2Eテストの`appId`を`host.exp.Exponent`(Expo Go)から`com.takudev.musicpracticetracker.development`(dev client)に変更
- Expo Go固有のプロジェクト選択ステップを削除
- Exploreタブ遷移後のアサーションを追加

## Test plan
- [ ] `maestro test packages/apps/mobile/tests/e2e/main-e2e.yaml` でE2Eテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)