### PR TITLE
chore(mobile): add production submit profiles for EAS

### DIFF
--- a/packages/apps/mobile/eas.json
+++ b/packages/apps/mobile/eas.json
@@ -46,6 +46,13 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "production"
+      },
+      "ios": {
+        "ascAppId": "6742276750"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add Android submit profile with `production` track for Google Play
- Add iOS submit profile with App Store Connect app ID for TestFlight/App Store
- Enables `eas build --auto-submit` for automated store submissions

## Test plan
- [ ] `eas build --platform android --profile production --auto-submit` submits to Google Play
- [ ] `eas build --platform ios --profile production --auto-submit` submits to App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)