### PR TITLE
fix(root): unblock secretlint v13 and typescript-eslint upgrades

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -18,8 +18,8 @@ coverage/
 .nyc_output/
 
 # Environment files
-.env
-.env.*
+**/.env
+**/.env.*
 
 # IDE
 .vscode/

--- a/packages/libs/eslint-plugins/src/plugin-backend/utils/prisma-helpers.ts
+++ b/packages/libs/eslint-plugins/src/plugin-backend/utils/prisma-helpers.ts
@@ -169,7 +169,7 @@ export function isPrismaFindMethod(node: TSESTree.Node): node is TSESTree.Member
 
   while (current) {
     if (current.type === AST_NODE_TYPES.MemberExpression) {
-      const memberExp = current as TSESTree.MemberExpression;
+      const memberExp: TSESTree.MemberExpression = current;
       const objectName =
         memberExp.object.type === AST_NODE_TYPES.Identifier
           ? memberExp.object.name


### PR DESCRIPTION
## Summary

Two CI failures surfaced by Renovate dependency PRs (#774, #777) that are actually pre-existing issues in `develop`:

- **secretlint v13**: New ripgrep-based walker stops honoring bare `.env.*` patterns for nested files. Anchor with `**/` so `packages/apps/admin/.env.test` is properly ignored under both v11 and v13.
- **`@typescript-eslint/no-unnecessary-type-assertion`**: Newer rule version flags `current as TSESTree.MemberExpression` in `isPrismaFindMethod` as redundant (TS already narrows via the discriminated union check). Replaced the cast with an explicit type annotation — needed because `current` is reassigned later in the loop, which otherwise causes TS7022 (circular inference) when the cast is simply removed.

## Test plan

- [x] `bun turbo lint:es:check type:check` (all 11 tasks pass)
- [x] `bun run lint:es:check:root`
- [x] `bun run type:check:root`
- [x] `bunx prettier --check` on changed files
- [ ] After merge: rebase #774 and #777 to confirm both CI failures are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)