### PR TITLE
fix(root): unblock secretlint v13 cascade and tighten typescript-eslint

### DIFF
--- a/packages/apps/admin/.gitignore
+++ b/packages/apps/admin/.gitignore
@@ -36,9 +36,8 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files (do not negate .env.test; secretlint v13 cascades .gitignore)
 .env*
-!.env.test
 
 # vercel
 .vercel

--- a/packages/apps/backend/tests/src/domain/utils/publicize.spec.ts
+++ b/packages/apps/backend/tests/src/domain/utils/publicize.spec.ts
@@ -91,7 +91,7 @@ describe('unit Publicize', () => {
 
       const publicize = <T extends { id: any }>(internal: T): Publicize<T> => {
         const { id, ...publicData } = internal;
-        return publicData as Publicize<T>;
+        return publicData;
       };
 
       const publicUser = publicize(internalUser);


### PR DESCRIPTION
## Summary

Follow-up to #778. The previous unblock PR was insufficient — CI for #774 and #777 still fails after rebase. Two new root causes:

### secretlint v13 (`Check Secret Lint` for #777)

v13's walker uses a **cascade ignore chain** with leaf → root, "first verdict wins" semantics (modeled after ripgrep). `packages/apps/admin/.gitignore` had:

```
.env*
!.env.test
```

The `!.env.test` negation made the leaf level un-ignore the symlink before root `.secretlintignore` (`**/.env.*`) ever got consulted. Result: the symlink's content (the generated test DSN at root `.env.test`) was scanned and tripped `secretlint-rule-database-connection-string`.

Fix: drop `!.env.test`. The symlink is already tracked in the git index (`120000` mode), so removing the explicit opt-in has no effect on existing tracking. Added a one-line warning so the negation doesn't get re-added.

Verified locally with v13 deps swapped in: `bun run lint:secret:check` → exit 0.

### typescript-eslint upgrade (`Check ESLint & Type` for #774)

After #778 fixed the prisma-helpers cast, the next stricter detection landed on `publicize.spec.ts:94`:

```ts
const publicize = <T extends { id: any }>(internal: T): Publicize<T> => {
  const { id, ...publicData } = internal;
  return publicData as Publicize<T>;  // ← unnecessary
};
```

`Publicize<T> = Omit<T, 'id'>`. After destructuring `id` out, `publicData` already has type `Omit<T, 'id'>` = `Publicize<T>`. The cast is a true no-op and the rule's stricter version correctly flags it.

## Test plan

- [x] `bun turbo lint:es:check type:check` — 11/11 pass
- [x] `bun run lint:es:check:root` / `bun run type:check:root` pass
- [x] `bun run lint:secret:check` (v11, current) → exit 0
- [x] Swapped to v13 locally → `bun run lint:secret:check` exit 0
- [ ] After merge: rebase #774 and #777 to confirm both CI failures clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)